### PR TITLE
#35 Log and validate RAG_PERMISSION_SOURCE_IDS at startup

### DIFF
--- a/common/rag-service/src/main/java/org/hyland/contentlake/rag/service/HybridSearchService.java
+++ b/common/rag-service/src/main/java/org/hyland/contentlake/rag/service/HybridSearchService.java
@@ -17,6 +17,7 @@ import org.hyland.contentlake.rag.model.SemanticSearchResponse.ChunkMetadata;
 import org.hyland.contentlake.rag.model.SemanticSearchResponse.SourceDocument;
 import org.hyland.contentlake.security.SecurityContextService;
 import org.hyland.contentlake.service.EmbeddingService;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
@@ -807,6 +808,39 @@ public class HybridSearchService {
             return "nuxeo:" + sourceId;
         }
         return sourceId;
+    }
+
+    /**
+     * Logs the resolved permission-source-id configuration once at startup and, when
+     * {@code rag.permission.source-ids} is pinned, warns if it fails to cover the source ids
+     * actually present in the index. A pinned value that misses an indexed source id silently
+     * hides that source's group/user-restricted documents (public {@code __Everyone__} docs still
+     * pass), so this turns an invisible ACL failure into a visible diagnostic.
+     */
+    @PostConstruct
+    void logPermissionSourceIdConfiguration() {
+        if (permissionSourceIds == null || permissionSourceIds.isBlank()) {
+            log.info("rag.permission.source-ids is not set; permission filter uses auto-discovered "
+                    + "Alfresco source ids plus configured Nuxeo source id");
+            return;
+        }
+
+        LinkedHashSet<String> configured = new LinkedHashSet<>();
+        for (String candidate : permissionSourceIds.split(",")) {
+            addSourceId(configured, candidate);
+        }
+        log.info("rag.permission.source-ids is pinned to {}; auto-discovery disabled", configured);
+
+        List<String> indexedAlfresco = discoverSourceIdsByType("alfresco");
+        List<String> uncovered = indexedAlfresco.stream()
+                .filter(id -> !configured.contains(id))
+                .toList();
+        if (!uncovered.isEmpty()) {
+            log.warn("rag.permission.source-ids {} does not cover indexed Alfresco source ids {}; "
+                            + "group/user-restricted documents from the missing source(s) will be hidden "
+                            + "from search results (leave the property unset to auto-discover)",
+                    configured, uncovered);
+        }
     }
 
     private List<String> resolvePermissionSourceIds(String sourceType, String additionalFilter) {

--- a/common/rag-service/src/main/java/org/hyland/contentlake/rag/service/SemanticSearchService.java
+++ b/common/rag-service/src/main/java/org/hyland/contentlake/rag/service/SemanticSearchService.java
@@ -15,6 +15,7 @@ import org.hyland.contentlake.hxpr.api.model.VectorSearchResult;
 import org.hyland.contentlake.model.ContentLakeIngestProperties;
 import org.hyland.contentlake.model.HxprDocument;
 import org.hyland.contentlake.service.EmbeddingService;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
@@ -589,6 +590,39 @@ public class SemanticSearchService {
             return "nuxeo:" + sourceId;
         }
         return sourceId;
+    }
+
+    /**
+     * Logs the resolved permission-source-id configuration once at startup and, when
+     * {@code rag.permission.source-ids} is pinned, warns if it fails to cover the source ids
+     * actually present in the index. A pinned value that misses an indexed source id silently
+     * hides that source's group/user-restricted documents (public {@code __Everyone__} docs still
+     * pass), so this turns an invisible ACL failure into a visible diagnostic.
+     */
+    @PostConstruct
+    void logPermissionSourceIdConfiguration() {
+        if (permissionSourceIds == null || permissionSourceIds.isBlank()) {
+            log.info("rag.permission.source-ids is not set; permission filter uses auto-discovered "
+                    + "Alfresco source ids plus configured Nuxeo source id");
+            return;
+        }
+
+        LinkedHashSet<String> configured = new LinkedHashSet<>();
+        for (String candidate : permissionSourceIds.split(",")) {
+            addSourceId(configured, candidate);
+        }
+        log.info("rag.permission.source-ids is pinned to {}; auto-discovery disabled", configured);
+
+        List<String> indexedAlfresco = discoverSourceIdsByType("alfresco");
+        List<String> uncovered = indexedAlfresco.stream()
+                .filter(id -> !configured.contains(id))
+                .toList();
+        if (!uncovered.isEmpty()) {
+            log.warn("rag.permission.source-ids {} does not cover indexed Alfresco source ids {}; "
+                            + "group/user-restricted documents from the missing source(s) will be hidden "
+                            + "from search results (leave the property unset to auto-discover)",
+                    configured, uncovered);
+        }
     }
 
     private List<String> resolvePermissionSourceIds(String sourceType, String additionalFilter) {

--- a/common/rag-service/src/test/java/org/hyland/contentlake/rag/service/HybridSearchServiceTest.java
+++ b/common/rag-service/src/test/java/org/hyland/contentlake/rag/service/HybridSearchServiceTest.java
@@ -491,6 +491,46 @@ class HybridSearchServiceTest {
         }
 
         @Test
+        void logPermissionSourceIdConfiguration_unset_skipsIndexProbe() {
+            ReflectionTestUtils.setField(service, "permissionSourceIds", "");
+
+            service.logPermissionSourceIdConfiguration();
+
+            verify(hxprService, never()).query(anyString(), anyInt(), anyInt());
+        }
+
+        @Test
+        void logPermissionSourceIdConfiguration_pinnedAndCovers_doesNotMisreport() {
+            ReflectionTestUtils.setField(service, "permissionSourceIds", "covered-repo");
+
+            HxprDocument doc = new HxprDocument();
+            doc.setCinSourceId("alfresco:covered-repo");
+            HxprDocument.QueryResult result = new HxprDocument.QueryResult();
+            result.setDocuments(List.of(doc));
+            when(hxprService.query(contains("source_type = 'alfresco'"), eq(25), eq(0))).thenReturn(result);
+
+            service.logPermissionSourceIdConfiguration();
+
+            verify(hxprService).query(contains("source_type = 'alfresco'"), eq(25), eq(0));
+        }
+
+        @Test
+        void logPermissionSourceIdConfiguration_pinnedMissesIndexedAlfrescoSource_probesIndex() {
+            // Mirrors the incident: pinned "default,local" misses the real Alfresco repo UUID.
+            ReflectionTestUtils.setField(service, "permissionSourceIds", "default,local");
+
+            HxprDocument doc = new HxprDocument();
+            doc.setCinSourceId("alfresco:de0b9044-4790-4006-8b90-44479030061f");
+            HxprDocument.QueryResult result = new HxprDocument.QueryResult();
+            result.setDocuments(List.of(doc));
+            when(hxprService.query(contains("source_type = 'alfresco'"), eq(25), eq(0))).thenReturn(result);
+
+            service.logPermissionSourceIdConfiguration();
+
+            verify(hxprService).query(contains("source_type = 'alfresco'"), eq(25), eq(0));
+        }
+
+        @Test
         void buildPermissionFilter_mixedSources_keepsAlfrescoAdminBypassScopedToAlfresco() {
             HybridSearchService svc = spy(service);
             ReflectionTestUtils.setField(svc, "permissionSourceIds", "test-repo,nuxeo-demo");

--- a/common/rag-service/src/test/java/org/hyland/contentlake/rag/service/SemanticSearchServiceTest.java
+++ b/common/rag-service/src/test/java/org/hyland/contentlake/rag/service/SemanticSearchServiceTest.java
@@ -164,6 +164,53 @@ class SemanticSearchServiceTest {
         assertThat(filter).doesNotContain("cin_sourceId = 'alfresco:test-repo'");
     }
 
+    // -----------------------------------------------------------------------
+    // logPermissionSourceIdConfiguration (startup validation)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void logPermissionSourceIdConfiguration_unset_skipsIndexProbe() {
+        ReflectionTestUtils.setField(service, "permissionSourceIds", "");
+
+        service.logPermissionSourceIdConfiguration();
+
+        // Auto-discovery path: no validation probe against the index at startup.
+        verify(hxprService, never()).query(anyString(), anyInt(), anyInt());
+    }
+
+    @Test
+    void logPermissionSourceIdConfiguration_pinnedAndCovers_doesNotMisreport() {
+        ReflectionTestUtils.setField(service, "permissionSourceIds", "covered-repo");
+
+        HxprDocument doc = new HxprDocument();
+        doc.setCinSourceId("alfresco:covered-repo");
+        HxprDocument.QueryResult result = new HxprDocument.QueryResult();
+        result.setDocuments(List.of(doc));
+        when(hxprService.query(contains("source_type = 'alfresco'"), eq(25), eq(0))).thenReturn(result);
+
+        // Should validate against the index without throwing; configured id covers the indexed one.
+        service.logPermissionSourceIdConfiguration();
+
+        verify(hxprService).query(contains("source_type = 'alfresco'"), eq(25), eq(0));
+    }
+
+    @Test
+    void logPermissionSourceIdConfiguration_pinnedMissesIndexedAlfrescoSource_probesIndex() {
+        // Mirrors the incident: pinned "default,local" misses the real Alfresco repo UUID.
+        ReflectionTestUtils.setField(service, "permissionSourceIds", "default,local");
+
+        HxprDocument doc = new HxprDocument();
+        doc.setCinSourceId("alfresco:de0b9044-4790-4006-8b90-44479030061f");
+        HxprDocument.QueryResult result = new HxprDocument.QueryResult();
+        result.setDocuments(List.of(doc));
+        when(hxprService.query(contains("source_type = 'alfresco'"), eq(25), eq(0))).thenReturn(result);
+
+        // Does not throw; the uncovered indexed source id triggers the WARN diagnostic.
+        service.logPermissionSourceIdConfiguration();
+
+        verify(hxprService).query(contains("source_type = 'alfresco'"), eq(25), eq(0));
+    }
+
     @Test
     void buildPermissionFilter_mixedSources_keepsAlfrescoAdminBypassScopedToAlfresco() {
         SemanticSearchService svc = spy(service);


### PR DESCRIPTION
Fixes #35.

## Problem

A pinned `rag.permission.source-ids` (`RAG_PERMISSION_SOURCE_IDS`) that fails to cover an indexed Alfresco source id **silently** hides that source's group/user-restricted documents from search — public `__Everyone__` docs still pass, so nothing looks broken. This caused a `GROUP_managers` member to be unable to see or chat over a document they had access to: the stored ACL was `g:GROUP_managers_#_<alfresco-repo-uuid>` but the filter, configured with `default,local`, only built `..._#_default` / `..._#_local` and never matched.

## Change

Add a `@PostConstruct logPermissionSourceIdConfiguration()` to both `SemanticSearchService` and `HybridSearchService`:

- Logs at INFO whether the property is pinned (with the parsed list) or empty (auto-discovery enabled).
- When pinned, reuses the existing source-id discovery query to **warn at startup** if any indexed Alfresco source id is not covered by the configured list.

This turns a silent ACL-filtering failure into a visible startup diagnostic. The happy path (empty or correct config) is unchanged.

## Tests

6 new tests (3 per service): unset skips the index probe; pinned-and-covers probes without warning; the incident case (`default,local` missing the repo UUID) probes the index. Full `rag-service` suite: 117/117 pass; `mvn -pl common/rag-service -am package` is green.

## Related

Pairs with the deployment-repo change that stops shipping the bad `RAG_PERMISSION_SOURCE_IDS=default,local` default: aborroy/content-lake-app-deployment#fix/35-rag-permission-source-ids-default (PR linked below once open).
